### PR TITLE
Run bal mock

### DIFF
--- a/bin/runbalfinder_pixel.py
+++ b/bin/runbalfinder_pixel.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+from glob import glob
+
+import argparse
+from baltools import desibal as db
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description="""Run balfinder on DESI data""")
+
+parser.add_argument('-i','--in-file', type = str, nargs='*', required = False,
+                    help = 'Path to input files to process') 
+
+parser.add_argument('--in-dir', type = str, required = False,
+                    help = 'Path to directory containing all files to process')
+ 
+parser.add_argument('-o','--out-dir', type = str, default = None, required = False,
+                    help = 'Path for output BAL catalog file')
+
+parser.add_argument('-r','--redo', type = bool, default = False, required = False,
+                    help = 'Redo (overwrite) BAL catalog if it already exists?')
+
+parser.add_argument('-v','--verbose', type = bool, default = False, required = False,
+                    help = 'Provide verbose output?')
+
+args  = parser.parse_args()
+
+# Identify the files to process
+if args.in_file is not None: 
+    files= args.in_file
+else: 
+    #Try to read and process all files in spectra directory
+    files = glob(args.in_dir+"/*/*/spectra*.fits")
+
+##Add a few lines here to skip already procesed files 
+
+#Run the BAL finder in each file... 
+for specfilename in files:
+     print("Procesisng:",specfilename)
+     db.desibalfinder(specfilename, overwrite=args.redo, verbose=False)
+
+

--- a/bin/runbalfinder_pixel.py
+++ b/bin/runbalfinder_pixel.py
@@ -14,13 +14,14 @@ parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFo
                                      description="""Run balfinder on DESI data""")
 
 parser.add_argument('-i','--in-file', type = str, nargs='*', required = False,
-                    help = 'Path to input files to process') 
+                    help = 'Path to input files to process')
 
 parser.add_argument('--in-dir', type = str, required = False,
                     help = 'Path to directory containing all files to process')
- 
-parser.add_argument('-o','--out-dir', type = str, default = None, required = False,
-                    help = 'Path for output BAL catalog file')
+
+#allow to specify the output directory
+#parser.add_argument('-o','--out-dir', type = str, default = None, required = False,
+#                    help = 'Path for output BAL catalog file')
 
 parser.add_argument('-r','--redo', type = bool, default = False, required = False,
                     help = 'Redo (overwrite) BAL catalog if it already exists?')
@@ -31,15 +32,15 @@ parser.add_argument('-v','--verbose', type = bool, default = False, required = F
 args  = parser.parse_args()
 
 # Identify the files to process
-if args.in_file is not None: 
+if args.in_file is not None:
     files= args.in_file
-else: 
+else:
     #Try to read and process all files in spectra directory
     files = glob(args.in_dir+"/*/*/spectra*.fits")
 
-##Add a few lines here to skip already procesed files 
+##TODO:Add a few lines here to skip already procesed files
 
-#Run the BAL finder in each file... 
+#Run the BAL finder in each file...
 for specfilename in files:
      print("Procesisng:",specfilename)
      db.desibalfinder(specfilename, overwrite=args.redo, verbose=False)

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -47,12 +47,12 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
     -------
     none
     ''' 
-    # Define some variable names based on the type of input file 
-    if 'spectra-' in specfilename: 
+    # Define some variable names based on the type of input file
+    if 'spectra-' in specfilename:
         specshort = specfilename[specfilename.rfind('spectra-'):specfilename.rfind('.fits')]
         zshort = specshort.replace('spectra', 'zbest')
         zfilename = specfilename.replace(specshort, zshort)
-    elif 'coadd-' in specfilename: 
+    elif 'coadd-' in specfilename:
         specshort = specfilename[specfilename.rfind('coadd-'):specfilename.rfind('.fits')]
         zshort = specshort.replace('coadd', 'zbest')
         zfilename = specfilename.replace(specshort, zshort)
@@ -60,39 +60,36 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
         print("Error: unable to find redshift file for {}".format(specfilename))
         return
 
-
-    # Define output file name and check if it exists if overwrite=False 
-    if 'spectra-' in specfilename: 
+    # Define output file name and check if it exists if overwrite=False
+    if 'spectra-' in specfilename:
         balshort = specshort.replace('spectra-', 'baltable-')
-    elif 'coadd-' in specfilename: 
+    elif 'coadd-' in specfilename:
         balshort = specshort.replace('coadd-', 'baltable-')
     else:
         print("Error: unable to interpret {}".format(specfilename))
         return
-    
+
     baltmp = specfilename.replace(specshort, balshort)
-    
-    if altbaldir is not None: 
+
+    if altbaldir is not None:
         balfilename = os.path.join(altbaldir + "/", baltmp[baltmp.rfind("baltable-")::])
-    else: 
+    else:
         balfilename = baltmp
-        
+
     print("Output BAL catalog:", balfilename)
-    
+
     if os.path.isfile(balfilename) and not overwrite:
         print("Bal catalog already exist")
         return
-    
 
-    # Read in the DESI spectra 
+    # Read in the DESI spectra
     specobj = desispec.io.read_spectra(specfilename)
 
-    # See if 3 cameras are coadded, and coadd them if they are not: 
-    # (at least some of the mock data are not coadded) 
+    # See if 3 cameras are coadded, and coadd them if they are not:
+    # (at least some of the mock data are not coadded)
     if 'brz' not in specobj.wave.keys():
         specobj = coadd_cameras(specobj, cosmics_nsig=None)
 
-    
 
     zs = fitsio.read(zfilename)
 
@@ -110,13 +107,13 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
         if zmask[index]: 
             dd[item].append(index)
             zqsos.append(index)
-            
+
     fm = specobj.fibermap
     # Create a list of the indices in specobj on which to run balfinder
     qsos = [index for item in fm["TARGETID"] for index in dd[item] if item in dd]
 
 
-    # Initialize the BAL table with all quasars in 'qsos' 
+    # Initialize the BAL table with all quasars in 'qsos'
     baltable.initbaltab_desi(fm[qsos], zs[zqsos], balfilename, overwrite=overwrite)
 
     balhdu = fits.open(balfilename) 


### PR DESCRIPTION
This PR adds two separate things: 
- a small and simple script to run the balfinder in mocks. it can run a single pixel or a list of them.
- I suggest to changed the order of some lines in `/py/baltools/desibal.py` so that it first checks for (non-)existing files, and then try to other things, otherwise it takes a while before failing. It isn's an issue if running with the `runbalfinder.py` because I think this also checks for (non-)existing files... but if we run in a mock it could take a some extra time to check two times... 

This PR has been tested in mocks but it would be good to test that I do not affected a run on data . 