### PR TITLE
Add patch to process quickqusars mocks v9.0.*

### DIFF
--- a/py/baltools/baltable.py
+++ b/py/baltools/baltable.py
@@ -114,7 +114,11 @@ def initbaltab_desi(specdata, zdata, outputfile, overwrite=False):
     col2 = fits.Column(name='TARGET_DEC', format='E', array=specdata['TARGET_DEC'])
     col3 = fits.Column(name='NIGHT', format='K', array=specdata['NIGHT'])
     col4 = fits.Column(name='EXPID', format='K', array=specdata['EXPID'])
-    col5 = fits.Column(name='MJD', format='E', array=specdata['MJD'])
+    if 'MJD' in specdata.colnames :
+        col5 = fits.Column(name='MJD', format='E', array=specdata['MJD'])
+    else :
+        col5 = fits.Column(name='MJD', format='E', array=np.empty(NROWS, dtype=float))
+        
     col6 = fits.Column(name='TILEID', format='k', array=specdata['TILEID'])
 
     # Columns to copy from the redshift data

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -16,7 +16,7 @@ import numpy as np
 import fitsio
 from astropy.io import fits
 import desispec.io
-from desispec.coaddition import coadd_cameras
+from desispec.coaddition import coadd_cameras,resample_spectra_lin_or_log
 from collections import defaultdict
 
 from baltools import fitbal
@@ -84,11 +84,19 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
 
     # Read in the DESI spectra
     specobj = desispec.io.read_spectra(specfilename)
-
     # See if 3 cameras are coadded, and coadd them if they are not:
     # (at least some of the mock data are not coadded)
     if 'brz' not in specobj.wave.keys():
-        specobj = coadd_cameras(specobj, cosmics_nsig=None)
+        try:
+            specobj = coadd_cameras(specobj, cosmics_nsig=None)
+        except:
+            wave_min = np.min(specobj.wave['b'])
+            wave_max= np.max(specobj.wave['z'])
+            specobj = resample_spectra_lin_or_log(specobj,linear_step=0.8, wave_min =wave_min, wave_max =wave_max, fast = True)
+            print(specobj.wave)
+            print("resampled flux")
+            specobj = coadd_cameras(specobj, cosmics_nsig=None)
+            
 
 
     zs = fitsio.read(zfilename)

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -93,8 +93,6 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
             wave_min = np.min(specobj.wave['b'])
             wave_max= np.max(specobj.wave['z'])
             specobj = resample_spectra_lin_or_log(specobj,linear_step=0.8, wave_min =wave_min, wave_max =wave_max, fast = True)
-            print(specobj.wave)
-            print("resampled flux")
             specobj = coadd_cameras(specobj, cosmics_nsig=None)
             
 
@@ -107,7 +105,8 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
     # BAL_ZMAX = 5.6
     zmask = zs['Z'] > bc.BAL_ZMIN
     zmask = zmask*(zs['Z'] < bc.BAL_ZMAX)
-    zmask = zmask*(zs['SPECTYPE'] == b'QSO')
+        
+    zmask = zmask*(zs['SPECTYPE'] =='QSO')
 
     zqsos = []
     dd = defaultdict(list)

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -91,9 +91,10 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
             specobj = coadd_cameras(specobj, cosmics_nsig=None)
         except:
             wave_min = np.min(specobj.wave['b'])
-            wave_max= np.max(specobj.wave['z'])
+            wave_max = np.max(specobj.wave['z'])
             specobj = resample_spectra_lin_or_log(specobj,linear_step=0.8, wave_min =wave_min, wave_max =wave_max, fast = True)
             specobj = coadd_cameras(specobj, cosmics_nsig=None)
+            print("coadded_cameras using lispace resample")
             
 
 
@@ -105,8 +106,11 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
     # BAL_ZMAX = 5.6
     zmask = zs['Z'] > bc.BAL_ZMIN
     zmask = zmask*(zs['Z'] < bc.BAL_ZMAX)
-        
-    zmask = zmask*(zs['SPECTYPE'] =='QSO')
+    
+    if 'QSO' in np.unique(zs['SPECTYPE']) :
+        zmask = zmask*(zs['SPECTYPE'] == 'QSO')
+    else :
+        zmask = zmask*(zs['SPECTYPE'] == 'bQSO')
 
     zqsos = []
     dd = defaultdict(list)


### PR DESCRIPTION
This PR is intended to fixe an error that occurs for the latest version of the mocks, that arise when coadding them, See [this issue](https://github.com/paulmartini/baltools/issues/3).

 However, a new issue appeared due to a recent change in desispec. The error that arise is: 

```
ERROR:coaddition.py:231:coadd_cameras: Cannot directly coadd the camera spectra because wavelength are not aligned, use --lin-step or --log10-step to resample to a common grid
{'brz': array([3569.30004883, 3570.10004883, 3570.90004883, ..., 9831.70004883,
       9832.50004883, 9833.30004883])}
resampled flux
Traceback (most recent call last):
  File "/global/homes/a/alxogm/desi/code/others/baltools/py/baltools/desibal.py", line 91, in desibalfinder
    specobj = coadd_cameras(specobj, cosmics_nsig=None)
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/py/desispec/coaddition.py", line 232, in coadd_cameras
    sys.exit(12)
SystemExit: 12

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/global/homes/a/alxogm/desi/code/others/baltools/bin/runbalfinder_pixel.py", line 46, in <module>
    db.desibalfinder(specfilename, overwrite=args.redo, verbose=False)
  File "/global/homes/a/alxogm/desi/code/others/baltools/py/baltools/desibal.py", line 98, in desibalfinder
    specobj = coadd_cameras(specobj, cosmics_nsig=None)
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/py/desispec/coaddition.py", line 355, in coadd_cameras
    fibermap = coadd_fibermap(spectra.fibermap)
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desispec/master/py/desispec/coaddition.py", line 75, in coadd_fibermap
    tfmap['COADD_EXPTIME'][i] = np.sum(fibermap['EXPTIME'][jj][good_coadds])
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/conda/lib/python3.8/site-packages/astropy/table/table.py", line 1602, in __getitem__
    return self.columns[item]
  File "/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/conda/lib/python3.8/site-packages/astropy/table/table.py", line 239, in __getitem__
    return OrderedDict.__getitem__(self, item)
KeyError: 'EXPTIME'
```

And I think is due to [this recent change]( https://github.com/desihub/desispec/commit/94cd4e5ebf8b275a68915794f1c017574689ff46#diff-66db6b690c4424fead9a749ff0b362d172abddd338ecb6ca34c965b4a0858e32.  )