### PR TITLE
Simonmf1

### DIFF
--- a/bin/appendbalinfo.py
+++ b/bin/appendbalinfo.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import numpy as np
+from astropy.io import fits
+
+import argparse
+
+sys.path.append("/global/homes/s/simonmf/baltools/py")
+from baltools import balconfig as bc
+from baltools import fitbal
+from baltools import initcreate as ic
+
+def pmmkdir(direct): 
+    if not os.path.isdir(direct):
+        try:
+            os.makedirs(direct)
+        except PermissionError:
+            print("Error: no permission to make directory ", direct)
+            exit(1)
+
+os.environ['DESI_SPECTRO_REDUX'] = '/global/cfs/cdirs/desi/spectro/redux'
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                     description="""Update existing QSO catalogue with BAL information""")
+
+parser.add_argument('-q', '--qsocat', type = str, default = ".", required = True,
+                    help = 'Input QSO catalogue for which information is to be added to')
+
+parser.add_argument('-b','--baldir', type=str, default=".", required=False,
+                    help='Path to directory structure with individual BAL catalogs')
+
+parser.add_argument('-o','--outdir', type = str, default = None, required = True,
+                    help = 'Root directory for output catalogue')
+
+parser.add_argument('-f','--filename', type=str, default="qsocat.fits", 
+                    required=False, help='Filename of output QSO catalog')
+
+parser.add_argument('-c','--clobber', type=bool, default=False, required=False,
+                    help='Clobber (overwrite) BAL catalog if it already exists?')
+
+parser.add_argument('-v','--verbose', type = bool, default = False, required = False,
+                    help = 'Provide verbose output?')
+
+
+args  = parser.parse_args()
+
+outdir   = args.outdir
+filename = args.filename
+qsocat   = args.qsocat
+baldir   = args.baldir
+
+if qsocat == ".":
+    print("Input QSO catalogue path is required. Exiting program.")
+    exit(1)
+if not os.path.isfile(qsocat):
+    print("Error: cannot find ", qsocat)
+    exit(1)
+
+if baldir == ".":
+    print("Root BAL directory path is required. Exiting program.")
+    exit(1)
+    
+# Checks whether outdir exists. If it does not, makes it if permitted.
+pmmkdir(outdir)
+    
+outpath = os.path.join(outdir, filename)
+# Adds empty BAL cols to qso cat and writes to outpath.
+# Stores return value (BAL card names) in cols
+cols = ic.inittab(qsocat, outpath)
+# Want to manually set this to -1 to show that it is not populated
+cols.remove('BAL_PROB')
+
+cathdu    = fits.open(qsocat)
+'''targetids = cathdu[1].data['TARGETID']'''
+lencat = len(cathdu[1].data['TARGETID'])
+
+'''for target in targetids:'''
+for catindex in range(lencat):
+    '''ic.popqsocat(outpath, baldir, target, cols, overwrite=args.clobber, verbose=args.verbose)'''
+    ic.popqsocat(outpath, baldir, catindex, cols, overwrite=args.clobber, verbose=args.verbose)
+    
+    if args.verbose:
+        print(("Target ", str(cathdu[1].data['TARGETID'][catindex]), " complete."))
+    
+    

--- a/bin/appendbalinfo.py
+++ b/bin/appendbalinfo.py
@@ -8,7 +8,7 @@ import argparse
 sys.path.append("/global/homes/s/simonmf/baltools/py")
 from baltools import balconfig as bc
 from baltools import fitbal
-from baltools import initcreate as ic
+from baltools import popqsotab as pt
 
 def pmmkdir(direct): 
     if not os.path.isdir(direct):
@@ -66,20 +66,19 @@ pmmkdir(outdir)
 outpath = os.path.join(outdir, filename)
 # Adds empty BAL cols to qso cat and writes to outpath.
 # Stores return value (BAL card names) in cols
-cols = ic.inittab(qsocat, outpath)
+cols = pt.inittab(qsocat, outpath)
 # Want to manually set this to -1 to show that it is not populated
 cols.remove('BAL_PROB')
 
 cathdu    = fits.open(qsocat)
-'''targetids = cathdu[1].data['TARGETID']'''
 lencat = len(cathdu[1].data['TARGETID'])
 
-'''for target in targetids:'''
 for catindex in range(lencat):
-    '''ic.popqsocat(outpath, baldir, target, cols, overwrite=args.clobber, verbose=args.verbose)'''
-    ic.popqsocat(outpath, baldir, catindex, cols, overwrite=args.clobber, verbose=args.verbose)
+    pt.addbalinfo(outpath, baldir, catindex, cols, overwrite=args.clobber, verbose=args.verbose)
+    
+    target = str(cathdu[1].data['TARGETID'][catindex])
     
     if args.verbose:
-        print(("Target ", str(cathdu[1].data['TARGETID'][catindex]), " complete."))
+        print(("Target ", target, " complete."))
     
     

--- a/bin/appendbalinfo.py
+++ b/bin/appendbalinfo.py
@@ -1,3 +1,16 @@
+"""
+
+baltools.appendbalinfo
+======================
+
+Utilizes functinos from popqsotab.py to add empty BAL columns to existing
+QSO catalogue and add information from baltables to new catalogue.
+runbalfinder.py tables
+
+2021 Original code by Simon Filbert
+
+"""
+
 import os
 import sys
 import numpy as np
@@ -5,7 +18,6 @@ from astropy.io import fits
 
 import argparse
 
-sys.path.append("/global/homes/s/simonmf/baltools/py")
 from baltools import balconfig as bc
 from baltools import fitbal
 from baltools import popqsotab as pt
@@ -13,6 +25,7 @@ from baltools import popqsotab as pt
 def pmmkdir(direct): 
     if not os.path.isdir(direct):
         try:
+            print(direct, "not found. Making new directory.")
             os.makedirs(direct)
         except PermissionError:
             print("Error: no permission to make directory ", direct)
@@ -23,10 +36,10 @@ os.environ['DESI_SPECTRO_REDUX'] = '/global/cfs/cdirs/desi/spectro/redux'
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="""Update existing QSO catalogue with BAL information""")
 
-parser.add_argument('-q', '--qsocat', type = str, default = ".", required = True,
+parser.add_argument('-q', '--qsocat', type = str, default = None, required = True,
                     help = 'Input QSO catalogue for which information is to be added to')
 
-parser.add_argument('-b','--baldir', type=str, default=".", required=False,
+parser.add_argument('-b','--baldir', type=str, default = None, required=True,
                     help='Path to directory structure with individual BAL catalogs')
 
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
@@ -49,19 +62,14 @@ filename = args.filename
 qsocat   = args.qsocat
 baldir   = args.baldir
 
-if qsocat == ".":
-    print("Input QSO catalogue path is required. Exiting program.")
-    exit(1)
+
 if not os.path.isfile(qsocat):
     print("Error: cannot find ", qsocat)
-    exit(1)
-
-if baldir == ".":
-    print("Root BAL directory path is required. Exiting program.")
     exit(1)
     
 # Checks whether outdir exists. If it does not, makes it if permitted.
 pmmkdir(outdir)
+
     
 outpath = os.path.join(outdir, filename)
 # Adds empty BAL cols to qso cat and writes to outpath.

--- a/bin/createbalcat.py
+++ b/bin/createbalcat.py
@@ -27,6 +27,7 @@ import fitsio
 import desispec.io
 from desispec.coaddition import coadd_cameras
 
+sys.path.append('/global/homes/s/simonmf/baltools/py')
 import baltools
 from baltools import balconfig as bc
 from baltools import plotter, fitbal, baltable
@@ -94,16 +95,20 @@ first = True
 for i in range(len(qtab)):
     if i == 0: 
         # Create empty BAL row for non-BALs based on a known, non-BAL
-        tileid = '68002'
-        night = '20200315'
-        sp = '7'
-        baltablename = os.path.join(balroot, tileid, night, "baltable-"+sp+"-"+tileid+"-"+night+".fits")
-        targetid = 35185977857147541# Known non-BAL
+        #tileid = '68002'
+        tileid = '1000'
+        #night = '20200315'
+        night = '20210517'
+        #sp = '7'
+        sp = '0'
+        baltablename = os.path.join(balroot, tileid, night, "baltable-"+sp+"-"+tileid+"-"+"thru"+night+".fits")
+        #targetid = 35185977857147541# Known non-BAL
+        targetid = 39627752483062578
         baltab = Table.read(baltablename)
         bindx = np.where(baltab['TARGETID'] == targetid)[0][0]
         emptybal = baltab.copy()
         emptybal.remove_columns(['TARGETID', 'TARGET_RA', 'TARGET_DEC',
-            'Z', 'ZERR', 'ZWARN', 'NIGHT', 'EXPID', 'MJD', 'TILEID'])
+            'Z', 'ZERR', 'ZWARN', 'TILEID'])
         emptybal = emptybal[bindx]
         emptybal['BAL_PROB'] = -1.
     zspec = qtab['Z'][i]
@@ -113,13 +118,13 @@ for i in range(len(qtab)):
         tileid = str(qtab['TILEID'][i])
         night = str(qtab['NIGHT'][i])
         sp = str(qtab['PETAL_LOC'][i])
-        baltablename = os.path.join(balroot, tileid, night, "baltable-"+sp+"-"+tileid+"-"+night+".fits")
+        baltablename = os.path.join(balroot, tileid, night, "baltable-"+sp+"-"+tileid+"-"+"thru"+night+".fits")
         if not os.path.isfile(baltablename):
             print("Warning: BAL catalog for TARGETID = ", targetid, "not found: ", baltablename)
         baltab = Table.read(baltablename)
         bindx = np.where(baltab['TARGETID'] == targetid)[0][0]
         baltab.remove_columns(['TARGETID', 'TARGET_RA', 'TARGET_DEC', 
-            'Z', 'ZERR', 'ZWARN', 'NIGHT', 'EXPID', 'MJD', 'TILEID'])
+            'Z', 'ZERR', 'ZWARN', 'TILEID'])
         newrow = hstack([qtab[i], baltab[bindx]])
         if first:
             outtab = newrow

--- a/bin/createbalcat.py
+++ b/bin/createbalcat.py
@@ -122,10 +122,14 @@ for i in range(len(qtab)):
         if not os.path.isfile(baltablename):
             print("Warning: BAL catalog for TARGETID = ", targetid, "not found: ", baltablename)
         baltab = Table.read(baltablename)
-        bindx = np.where(baltab['TARGETID'] == targetid)[0][0]
-        baltab.remove_columns(['TARGETID', 'TARGET_RA', 'TARGET_DEC', 
-            'Z', 'ZERR', 'ZWARN', 'TILEID'])
-        newrow = hstack([qtab[i], baltab[bindx]])
+        if targetid in baltab['TARGETID']:
+            bindx = np.where(baltab['TARGETID'] == targetid)[0][0]
+            baltab.remove_columns(['TARGETID', 'TARGET_RA', 'TARGET_DEC', 
+               'Z', 'ZERR', 'ZWARN', 'TILEID'])
+            newrow = hstack([qtab[i], baltab[bindx]])
+        else: 
+            newrow = hstack([qtab[i], emptybal])
+            newrow['BAL_PROB'] = -1.
         if first:
             outtab = newrow
             first = False

--- a/bin/createbalcat.py
+++ b/bin/createbalcat.py
@@ -27,13 +27,12 @@ import fitsio
 import desispec.io
 from desispec.coaddition import coadd_cameras
 
-sys.path.append('/global/homes/s/simonmf/baltools/py')
 import baltools
 from baltools import balconfig as bc
 from baltools import plotter, fitbal, baltable
 from baltools import desibal as db
 
-debug = True
+debug = False
 
 os.environ['DESI_SPECTRO_REDUX'] = '/global/cfs/cdirs/desi/spectro/redux/'
 
@@ -142,6 +141,9 @@ for i in range(len(qtab)):
             first = False
         else: 
             outtab = vstack([outtab, newrow])
+    #if i % 1000 == 0:
+        #outtab.write(balcatname, format='fits', overwrite=True)
+        #print('Updated BAL catalog. Wrote to ', balcatname)
 
 
 outtab.write(balcatname, format='fits', overwrite=True)

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -22,7 +22,6 @@ from collections import defaultdict
 import desispec.io
 from desispec.coaddition import coadd_cameras
 
-sys.path.append('/global/homes/s/simonmf/baltools/py')
 import baltools
 from baltools import balconfig as bc
 from baltools import plotter, fitbal, baltable
@@ -55,7 +54,7 @@ parser.add_argument('-s', '--specprod', type = str, default = 'andes', required 
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
                     help = 'Root directory for output files')
 
-parser.add_argument('-e', '--dirextension', type = str, default = None, required = False,
+parser.add_argument('-n', '--dirname', type = str, default = None, required = False,
                    help = 'Name of directory for output files')
 
 parser.add_argument('-c','--clobber', type=bool, default=False, required=False,
@@ -72,6 +71,11 @@ if debug:
     
 release = args.specprod
 
+if args.dirname == None:
+    dirname = release
+else:
+    dirname = args.dirname
+
 # Root directory for input data: 
 dataroot = os.path.join(os.getenv("DESI_SPECTRO_REDUX"), release, "tiles")
 if release == 'daily':
@@ -81,7 +85,6 @@ if not os.path.isdir(dataroot):
     exit(1)
     
 # Root directory for output catalogs: 
-dirname = release + args.dirextension 
 outroot = os.path.join(args.outdir, dirname, "tiles")
 pmmkdir(outroot)
 

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 import desispec.io
 from desispec.coaddition import coadd_cameras
 
+sys.path.append('/global/homes/s/simonmf/baltools/py')
 import baltools
 from baltools import balconfig as bc
 from baltools import plotter, fitbal, baltable
@@ -64,15 +65,17 @@ args  = parser.parse_args()
 
 if debug: 
     args.verbose=True
+    
+release = args.specprod
 
 # Root directory for input data: 
-dataroot = os.path.join(os.getenv("DESI_SPECTRO_REDUX"), args.specprod, "tiles")
+dataroot = os.path.join(os.getenv("DESI_SPECTRO_REDUX"), release, "tiles")
 if not os.path.isdir(dataroot): 
     print("Error: did not find root directory ", dataroot)
     exit(1)
-
+    
 # Root directory for output catalogs: 
-outroot = os.path.join(args.outdir, args.specprod, "tiles")
+outroot = os.path.join(args.outdir, release, "tiles")
 pmmkdir(outroot)
 
 # Determine which tile(s) to process

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -51,14 +51,20 @@ parser.add_argument('-d', '--date', nargs='*', default = None, required = False,
 parser.add_argument('-s', '--specprod', type = str, default = 'andes', required = False,
                     help = 'Specprod (data release subdirectory, default is andes)')
 
-parser.add_argument('-q', '--qsocat', type = str, default = None, required = False,
-                   help = 'QSO cat which tiles will be taken from')
-
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
                     help = 'Root directory for output files')
+'''
+# THE FOLLOWING 3 OPTIONS ARE STILL IN PROGRESS #
+
+parser.add_argument('-q', '--qsocat', type = str, default = None, required = False,
+                   help = 'Input QSO catalogue for tiles or spectypes')
+
+parser.add_argument('--use_cat_tiles', type = bool, defualt=False, required=False,
+                   help = 'Run code on all tiles in the catalogue?') 
 
 parser.add_argument('--use_cat_spectypes', type = bool, default=False, required=False,
                     help = 'Use spectypes from catalogue instead of from zbest')
+'''
 
 parser.add_argument('-c','--clobber', type = bool, default=False, required=False,
                     help = 'Clobber (overwrite) BAL catalog if it already exists?')

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -55,11 +55,15 @@ parser.add_argument('-s', '--specprod', type = str, default = 'andes', required 
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
                     help = 'Root directory for output files')
 
+parser.add_argument('-e', '--dirextension', type = str, default = None, required = False,
+                   help = 'Name of directory for output files')
+
 parser.add_argument('-c','--clobber', type=bool, default=False, required=False,
                     help='Clobber (overwrite) BAL catalog if it already exists?')
 
 parser.add_argument('-v','--verbose', type = bool, default = False, required = False,
                     help = 'Provide verbose output?')
+
 
 args  = parser.parse_args()
 
@@ -70,13 +74,17 @@ release = args.specprod
 
 # Root directory for input data: 
 dataroot = os.path.join(os.getenv("DESI_SPECTRO_REDUX"), release, "tiles")
+if release == 'daily':
+    dataroot = os.path.join(dataroot, 'cumulative')
 if not os.path.isdir(dataroot): 
     print("Error: did not find root directory ", dataroot)
     exit(1)
     
 # Root directory for output catalogs: 
-outroot = os.path.join(args.outdir, release, "tiles")
+dirname = release + args.dirextension 
+outroot = os.path.join(args.outdir, dirname, "tiles")
 pmmkdir(outroot)
+
 
 # Determine which tile(s) to process
 
@@ -119,5 +127,5 @@ for tile in inputtiles:
                 print("Coadd file: ", coaddfile)
 
             if not os.path.isfile(balfilename) or args.clobber: 
-                db.desibalfinder(coaddfile, altbaldir=outdatedir, overwrite=args.clobber, verbose=True)
+                db.desibalfinder(coaddfile, altbaldir=outdatedir, overwrite=args.clobber, verbose=True, release=release)
 

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -51,11 +51,17 @@ parser.add_argument('-d', '--date', nargs='*', default = None, required = False,
 parser.add_argument('-s', '--specprod', type = str, default = 'andes', required = False,
                     help = 'Specprod (data release subdirectory, default is andes)')
 
+parser.add_argument('-q', '--qsocat', type = str, default = None, required = False,
+                   help = 'QSO cat which tiles will be taken from')
+
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
                     help = 'Root directory for output files')
 
-parser.add_argument('-c','--clobber', type=bool, default=False, required=False,
-                    help='Clobber (overwrite) BAL catalog if it already exists?')
+parser.add_argument('--use_cat_spectypes', type = bool, default=False, required=False,
+                    help = 'Use spectypes from catalogue instead of from zbest')
+
+parser.add_argument('-c','--clobber', type = bool, default=False, required=False,
+                    help = 'Clobber (overwrite) BAL catalog if it already exists?')
 
 parser.add_argument('-v','--verbose', type = bool, default = False, required = False,
                     help = 'Provide verbose output?')

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -54,9 +54,6 @@ parser.add_argument('-s', '--specprod', type = str, default = 'andes', required 
 parser.add_argument('-o','--outdir', type = str, default = None, required = True,
                     help = 'Root directory for output files')
 
-parser.add_argument('-n', '--dirname', type = str, default = None, required = False,
-                   help = 'Name of directory for output files')
-
 parser.add_argument('-c','--clobber', type=bool, default=False, required=False,
                     help='Clobber (overwrite) BAL catalog if it already exists?')
 
@@ -71,11 +68,6 @@ if debug:
     
 release = args.specprod
 
-if args.dirname == None:
-    dirname = release
-else:
-    dirname = args.dirname
-
 # Root directory for input data: 
 dataroot = os.path.join(os.getenv("DESI_SPECTRO_REDUX"), release, "tiles")
 if release == 'daily':
@@ -85,7 +77,7 @@ if not os.path.isdir(dataroot):
     exit(1)
     
 # Root directory for output catalogs: 
-outroot = os.path.join(args.outdir, dirname, "tiles")
+outroot = os.path.join(args.outdir, release, "tiles")
 pmmkdir(outroot)
 
 # List of tiles that caused issues for by hand rerun.

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -88,6 +88,8 @@ if not os.path.isdir(dataroot):
 outroot = os.path.join(args.outdir, dirname, "tiles")
 pmmkdir(outroot)
 
+# List of tiles that caused issues for by hand rerun.
+issuetiles = []
 
 # Determine which tile(s) to process
 
@@ -130,5 +132,12 @@ for tile in inputtiles:
                 print("Coadd file: ", coaddfile)
 
             if not os.path.isfile(balfilename) or args.clobber: 
-                db.desibalfinder(coaddfile, altbaldir=outdatedir, overwrite=args.clobber, verbose=True, release=release)
-
+                try:
+                    db.desibalfinder(coaddfile, altbaldir=outdatedir, overwrite=args.clobber, verbose=True, release=release)
+                except:
+                    print("An error occured at tile {}. Adding tile to issuetiles list.".format(tile))
+                    issuetiles.append(tile)
+                    
+print("Errors occured at the tiles: ")
+for issuetile in issuetiles:
+    print(issuetile, end=" "),

--- a/bin/runbalfinder.py
+++ b/bin/runbalfinder.py
@@ -94,6 +94,7 @@ pmmkdir(outroot)
 
 # List of tiles that caused issues for by hand rerun.
 issuetiles = []
+errortypes = []
 
 # Determine which tile(s) to process
 
@@ -140,8 +141,10 @@ for tile in inputtiles:
                     db.desibalfinder(coaddfile, altbaldir=outdatedir, overwrite=args.clobber, verbose=True, release=release)
                 except:
                     print("An error occured at tile {}. Adding tile to issuetiles list.".format(tile))
+                    errorytpe = sys.exc_info()[0]
                     issuetiles.append(tile)
+                    errortypes.append(errortype)
                     
-print("Errors occured at the tiles: ")
-for issuetile in issuetiles:
-    print(issuetile, end=" "),
+print("Tiles with errors and error types: ")
+for i in range(len(issuetiles)):
+    print("{} : {}".format(issuetiles[i], errortypes[i]))

--- a/py/baltools/baltable.py
+++ b/py/baltools/baltable.py
@@ -83,7 +83,7 @@ def cattobalinfo(array):
 # ------------ DESI routines ---------------
 #
 
-def initbaltab_desi(specdata, zdata, outputfile, overwrite=False):
+def initbaltab_desi(specdata, zdata, outputfile, overwrite=False, release=None):
     '''
     Create an empty BAL table from a QSO catalog
     This should just include QSOs in the BAL redshift range
@@ -96,6 +96,7 @@ def initbaltab_desi(specdata, zdata, outputfile, overwrite=False):
         redshift data for qsos to search
     outputfile : fitsfile
         name to use for output BAL catalog file
+    release 
 
     Returns
     -------

--- a/py/baltools/baltable.py
+++ b/py/baltools/baltable.py
@@ -96,7 +96,8 @@ def initbaltab_desi(specdata, zdata, outputfile, overwrite=False, release=None):
         redshift data for qsos to search
     outputfile : fitsfile
         name to use for output BAL catalog file
-    release 
+    release : string
+        name of the data release that data comes from
 
     Returns
     -------
@@ -113,6 +114,9 @@ def initbaltab_desi(specdata, zdata, outputfile, overwrite=False, release=None):
     col0 = fits.Column(name='TARGETID', format='K', array=specdata['TARGETID'])
     col1 = fits.Column(name='TARGET_RA', format='E', array=specdata['TARGET_RA'])
     col2 = fits.Column(name='TARGET_DEC', format='E', array=specdata['TARGET_DEC'])
+    if release == 'daily':
+        col3 = fits.Column(name='LAST_NIGHT', format='K', array=specdata['LAST_NIGHT'])
+    E
     col3 = fits.Column(name='NIGHT', format='K', array=specdata['NIGHT'])
     col4 = fits.Column(name='EXPID', format='K', array=specdata['EXPID'])
     if 'MJD' in specdata.colnames :

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 from baltools import fitbal
 from baltools import balconfig as bc
 from baltools import baltable
+import getpass
 
 
 
@@ -108,7 +109,7 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False, r
     # Identify the spectra classified as quasars based on zs and within 
     # the nominal redshift range for BALs
     # BAL_ZMIN = 1.57
-    # BAL_ZMAX = 5.6
+    # BAL_ZMAX = 5.0
     zmask = zs['Z'] > bc.BAL_ZMIN
     zmask = zmask*(zs['Z'] < bc.BAL_ZMAX)
     
@@ -157,6 +158,6 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False, r
         print("Wrote BAL catalog {0}".format(balfilename))
 
     balhdu.writeto(balfilename, overwrite=True)
-    lastupdate = "Last updated {0} UT by {1}".format(strftime("%Y-%m-%d %H:%M:%S", gmtime()), os.getlogin())
+    lastupdate = "Last updated {0} UT by {1}".format(strftime("%Y-%m-%d %H:%M:%S", gmtime()), getpass.getuser())
     fits.setval(balfilename, 'HISTORY', value=lastupdate, ext=1)
 

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -130,7 +130,7 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False, r
 
 
     # Initialize the BAL table with all quasars in 'qsos'
-    baltable.initbaltab_desi(fm[qsos], zs[zqsos], balfilename, overwrite=overwrite)
+    baltable.initbaltab_desi(fm[qsos], zs[zqsos], balfilename, overwrite=overwrite, release=release)
 
     balhdu = fits.open(balfilename) 
 

--- a/py/baltools/desibal.py
+++ b/py/baltools/desibal.py
@@ -27,7 +27,7 @@ from baltools import baltable
 
 
 
-def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False): 
+def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False, release=None): 
     '''
     Find BALs in DESI quasars
     1. Identify all objects classified as quasars that are in the redshift
@@ -45,6 +45,8 @@ def desibalfinder(specfilename, altbaldir=None, overwrite=True, verbose=False):
         Overwrite the BAL catalog if it exists? (default is True)
     verbose : bool, optional
         Provide verbose output? (default is False)
+    release : string, optional
+        Specifies the release that the catalog comes from. (default if None)
 
     Returns
     -------

--- a/py/baltools/popqsotab.py
+++ b/py/baltools/popqsotab.py
@@ -135,8 +135,7 @@ def inittab(qsocatpath, outtab):
     
     return balcolnames 
 
-
-'''def popqsocat(cattab, rootbaldir, targetid, colnames, overwrite=False, verbose=False):'''    
+  
 def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=False):
     '''
     Write BAL information to QSO catalogue table with BAL information.
@@ -147,8 +146,6 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
         catalogue that BAL information is to be added to.
     rootbaldir : str
         path to root directory containing bal tables
-    ###targetid : np.int64
-        specific object 'TARGETID' which BAL info is being populated for.###
     cindx : int
         index of targetid in qso catalogue        
     colnames : list, strings
@@ -176,7 +173,6 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
     
     # Indices of objects in BAL info catalogue and QSO catalogue 
     # are not necessarily the same.
-    '''cindx = np.where(cathdu[1].data['TARGETID'] == targetid)[0][0]'''
     targetid = cathdu[1].data['TARGETID'][cindx]
     
     tile  = str(cathdu[1].data['TILEID'][cindx])
@@ -185,6 +181,7 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
     night = str(cathdu[1].data['LAST_NIGHT'][cindx])
     spec  = str(cathdu[1].data['PETAL_LOC'][cindx])
     
+    # Find bal table for specific object, open corresponding fits file
     baltabpath = os.path.join(rootbaldir, tile, night, "baltable-{}-{}-thru{}.fits".format(spec, tile, night))
     balhdu = fits.open(baltabpath)
 
@@ -192,7 +189,7 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
             print("BAL information for target ", str(targetid), " being read from ", str(baltabpath))
     
     # IndexError may imply that the target is in the QSO cat but not in the BAL cat. 
-    # Below handles this error.
+    # Below populated empty bal columns and adds bitmasks for classifications.
     if targetid in balhdu[1].data['TARGETID']: 
         bindx = np.where(balhdu[1].data['TARGETID'] == targetid)[0][0]
         
@@ -211,7 +208,7 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
     # NOTE: Add reference to zbest file for object to check whether object is QSO and that is why
     # it is not in redshift range, or if it is simply not in the catalogue.
     
-    else:
+    else: # if not found in bal table for any reason
         if verbose:
             print("Target ",  str(targetid), " not found in bal tables. Information not added")
         cathdu[1].data['BAL_PROB'][cindx] = -1     
@@ -234,6 +231,7 @@ def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=Fal
             print("Target ", str(targetid), " has significant difference in redshifts between BAL table and qso cat.") 
         cathdu[1].data['BALMASK'][cindx] += 4 #Indicates object is not in baltabs for another reason.
         
+    # Keep track of number of objects ran
     print(cindx)
     #balhdu.close()
     #cathdu.close()

--- a/py/baltools/popqsotab.py
+++ b/py/baltools/popqsotab.py
@@ -1,0 +1,239 @@
+"""
+
+baltools.initcreate
+===================
+
+Contains functions that add BAL columns to an existing QSO catalogue and
+populate empty columns for a given object with information attained from
+runbalfinder.py tables
+
+2021 Original code by Simon Filbert
+
+inittab()    : add empty columns for BAL info to existing QSO catalogue
+popqsocat() : populate empty columns with BAL information 
+
+"""
+
+
+import os
+import sys
+import numpy as np
+from astropy.io import fits
+
+sys.path.append("/global/homes/s/simonmf/baltools/py")
+from baltools import balconfig as bc
+from baltools import fitbal
+
+
+def inittab(qsocatpath, outtab):
+    '''
+    Populate table with information from QSO catalogue,
+    make empty tables for BAL information to be added later.
+
+    Parameters
+    ----------
+    qsocatpath : fits file
+        QSO catalogue to be read.
+    outtab  : fits file
+        where to write resulting catalogue to.
+
+    Returns
+    -------
+    colnames : list
+        card names in relating to BALs
+    
+    '''
+    
+    #Open input catalogue fits file to get num objects in catalogue.
+    cathdu = fits.open(qsocatpath)
+    NROWS  = len(cathdu[1].data)
+    
+    # PCA Fit Coefficients and chisq result
+    pca_array = np.zeros([NROWS, bc.NPCA], dtype=float)  # PCA Fit Coefficients
+    col0 = fits.Column(name='PCA_COEFFS', format='5E', array=pca_array)
+    pca_chi2 = np.zeros([NROWS], dtype=float)  # PCA reduced chi2
+    col1 = fits.Column(name='PCA_CHI2', format='E', array=pca_chi2)
+
+    # Collection of empty arrays to set up rest of the BAL catalog
+    # PM Note: Might change to -1. to indicate empty field
+    zfloat_col = np.zeros([NROWS], dtype=float)
+    zint_col = np.zeros([NROWS], dtype=float)
+    zneg_col = np.array([-99]*NROWS, dtype=float) # For BAL_PROB
+    zbit_col = np.array(NROWS, dtype=int) # For bit masking in BALMASK
+    zfloat_bicol = np.zeros([NROWS, bc.NBI], dtype=float) # Second dimension is max number of BI troughs
+    zfloat_aicol = np.zeros([NROWS, bc.NAI], dtype=float) # Second dimension is max number of AI troughs
+
+    # This will come from CNN Classifier
+    # All set to -99 to indicate that data from BALcats not been read yet
+    # Will be set to -1 once updated
+    col2 = fits.Column(name='BAL_PROB', format='E', array=zneg_col)
+
+    # These quantities are from trough fit
+    col3 = fits.Column(name='BI_CIV', format='E', array=zfloat_col)
+    col4 = fits.Column(name='ERR_BI_CIV', format='E', array=zfloat_col)
+    col5 = fits.Column(name='NCIV_2000', format='J', array=zint_col)
+    col6 = fits.Column(name='VMIN_CIV_2000', format='5E', array=zfloat_bicol)
+    col7 = fits.Column(name='VMAX_CIV_2000', format='5E', array=zfloat_bicol)
+    col8 = fits.Column(name='POSMIN_CIV_2000', format='5E', array=zfloat_bicol)
+    col9 = fits.Column(name='FMIN_CIV_2000', format='5E', array=zfloat_bicol)
+
+    col10 = fits.Column(name='AI_CIV', format='E', array=zfloat_col)
+    col11 = fits.Column(name='ERR_AI_CIV', format='E', array=zfloat_col)
+    col12 = fits.Column(name='NCIV_450', format='J', array=zint_col)
+    col13 = fits.Column(name='VMIN_CIV_450', format='17E', array=zfloat_aicol)
+    col14 = fits.Column(name='VMAX_CIV_450', format='17E', array=zfloat_aicol)
+    col15 = fits.Column(name='POSMIN_CIV_450', format='17E', array=zfloat_aicol)
+    col16 = fits.Column(name='FMIN_CIV_450', format='17E', array=zfloat_aicol)
+
+    col17 = fits.Column(name='BI_SIIV', format='E', array=zfloat_col)
+    col18 = fits.Column(name='ERR_BI_SIIV', format='E', array=zfloat_col)
+    col19 = fits.Column(name='NSIIV_2000', format='J', array=zint_col)
+    col20 = fits.Column(name='VMIN_SIIV_2000', format='5E', array=zfloat_bicol)
+    col21 = fits.Column(name='VMAX_SIIV_2000', format='5E', array=zfloat_bicol)
+    col22 = fits.Column(name='POSMIN_SIIV_2000', format='5E', array=zfloat_bicol)
+    col23 = fits.Column(name='FMIN_SIIV_2000', format='5E', array=zfloat_bicol)
+
+    col24 = fits.Column(name='AI_SIIV', format='E', array=zfloat_col)
+    col25 = fits.Column(name='ERR_AI_SIIV', format='E', array=zfloat_col)
+    col26 = fits.Column(name='NSIIV_450', format='J', array=zint_col)
+    col27 = fits.Column(name='VMIN_SIIV_450', format='17E', array=zfloat_aicol)
+    col28 = fits.Column(name='VMAX_SIIV_450', format='17E', array=zfloat_aicol)
+    col29 = fits.Column(name='POSMIN_SIIV_450', format='17E', array=zfloat_aicol)
+    col30 = fits.Column(name='FMIN_SIIV_450', format='17E', array=zfloat_aicol)
+    
+   # Seperate column not populated in runbalfinder which serves as a flag
+    col31 = fits.Column(name='BALMASK', format='E', array=zfloat_col)
+    
+    
+    #Columns relating to BAL information
+    BALcols = fits.ColDefs([col0, col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15, col16, col17, col18, col19, col20, col21, col22,           col23, col24, col25, col26, col27, col28, col29, col30])
+    
+    #Columns already contained in QSO catalogue
+    catcols = cathdu[1].columns
+    
+    totcols  = catcols + BALcols + col31
+    
+    #List of card names in BinHDU relating to BALs
+    #Will beiterated through in initcreate.popqsotab()
+    balcolnames = BALcols.info('name', False)['name']
+    
+    
+    #Create a new BinHDU with all columns
+    newbhdu = fits.BinTableHDU.from_columns(totcols)
+    #Update BinHDU of cathdu with newbhdu
+    cathdu[1] = newbhdu 
+    
+    try:
+        cathdu.writeto(outtab)
+    ###FIXME### Make so that if overwrite is true, the catalogue is completely overwritten with new information.
+    except OSError:
+        print("File ", outtab, " already exists. Choose another name")
+        
+        
+    
+    print("Empty BAL columns added to input QSO catalogue at ", str(qsocatpath), " and written to ", str(outtab), ".")
+    
+    return balcolnames 
+
+
+'''def popqsocat(cattab, rootbaldir, targetid, colnames, overwrite=False, verbose=False):'''    
+def addbalinfo(cattab, rootbaldir, cindx, colnames, overwrite=False, verbose=False):
+    '''
+    Write BAL information to QSO catalogue table with BAL information.
+    
+    Parameters
+    ----------
+    cattab : fits file
+        catalogue that BAL information is to be added to.
+    rootbaldir : str
+        path to root directory containing bal tables
+    ###targetid : np.int64
+        specific object 'TARGETID' which BAL info is being populated for.###
+    cindx : int
+        index of targetid in qso catalogue        
+    colnames : list, strings
+        list of columns in fits file which are to contain BAL info.
+    overwrite : bool
+        overwrite current table (if exists)?
+    verbose : bool
+        provide verbose output?
+    
+    Returns
+    -------
+    none
+    
+    
+    Bitmask definitions
+
+0       Successfully ran balfinder 
+1       Not found in a baltable
+2       Out of the redshift range to identify BALs
+4       Redshift difference between QSO catalog and baltable
+
+    '''
+    
+    cathdu = fits.open(cattab, mode='update')
+    
+    # Indices of objects in BAL info catalogue and QSO catalogue 
+    # are not necessarily the same.
+    '''cindx = np.where(cathdu[1].data['TARGETID'] == targetid)[0][0]'''
+    targetid = cathdu[1].data['TARGETID'][cindx]
+    
+    tile  = str(cathdu[1].data['TILEID'][cindx])
+    # runbalfinder.py uses last_night card to specify observation night
+    # as of (last check) 06/24/2021
+    night = str(cathdu[1].data['LAST_NIGHT'][cindx])
+    spec  = str(cathdu[1].data['PETAL_LOC'][cindx])
+    
+    baltabpath = os.path.join(rootbaldir, tile, night, "baltable-{}-{}-thru{}.fits".format(spec, tile, night))
+    balhdu = fits.open(baltabpath)
+
+    if verbose:
+            print("BAL information for target ", str(targetid), " being read from ", str(baltabpath))
+    
+    # IndexError may imply that the target is in the QSO cat but not in the BAL cat. 
+    # Below handles this error.
+    if targetid in balhdu[1].data['TARGETID']: 
+        bindx = np.where(balhdu[1].data['TARGETID'] == targetid)[0][0]
+        
+        if cathdu[1].data['BAL_PROB'][cindx] == -1 and not overwrite:
+            print("BAL information already exists for targetid ", str(targetid), " and overwrite == False. Moving to next target.")
+            
+        else:
+            # Read in BAL information from BAL table, populate QSO catalogue with this info.
+            for colname in colnames:
+                cathdu[1].data[colname][cindx] = balhdu[1].data[colname][bindx]
+
+                # Indicates that BAL data was added to the catalogue, but BAL_PROB is still an unpopulated field.
+                cathdu[1].data['BAL_PROB'][cindx] = -1 
+                cathdu[1].data['BALMASK'][cindx]  = 0 # Indicates object is in baltable and in redshift range 
+
+    # NOTE: Add reference to zbest file for object to check whether object is QSO and that is why
+    # it is not in redshift range, or if it is simply not in the catalogue.
+    
+    else:
+        if verbose:
+            print("Target ",  str(targetid), " not found in bal tables. Information not added")
+        cathdu[1].data['BAL_PROB'][cindx] = -1     
+        cathdu[1].data['BALPROB'][cindx]  = 1
+    
+    # Checks if z of object in catdata is outside of z range for runbalfinder for bit mask
+    if cathdu[1].data['Z'][cindx] > bc.BAL_ZMAX or cathdu[1].data['Z'][cindx] < bc.BAL_ZMIN:
+        if verbose:
+            print("Target ",  str(targetid), " not in redshift range.") 
+        cathdu[1].data['BALMASK'][cindx] += 2   
+    # If objects are in z range and still in catalogue, this suggests that the object is not identified
+    # as a QSO by RR.
+    
+    ztol = 0.001 # Tolarance for differences in z between catalogues
+    zc   = cathdu[1].data['Z'][cindx] # z from qso catalogue for object
+    zb   = balhdu[1].data['Z'][bindx] # z from bal table for object
+    dz   = abs(zc - zb) 
+    if dz > ztol:
+        if verbose:
+            print("Target ", str(targetid), " has significant difference in redshifts between BAL table and qso cat.") 
+        cathdu[1].data['BALMASK'][cindx] += 4 #Indicates object is not in baltabs for another reason.
+        
+    print(cindx)
+    #balhdu.close()
+    #cathdu.close()


### PR DESCRIPTION
runbalfinder.py:
- Three options in this module that are commented out are still in progress. 
- Error handling for tiles that have issues running for convenience in batch scripting. 
- Added 'release' variable to hold args.specprod. Other minor changes.

createbalcat.py:
- Made changed that allow code to be run on specific QSO catalogues from daily cumulative tiles.

baltable.py: 
- Added 'release' parameter to function initbaltab_desi to use 'cumulative' group tiles if the release is daily.

desibal.py: 
- Added 'release' parameter to function desibalfinder so it can be passed to baltable.initbaltab_desi later.
- Changed BAL_ZMAX to 5.0 to avoid error when searching for BAL features. 
- Changed os.getlogin() to getpass.getuser() for functionality with batch scripting.

Added popqsotab.py which has functions to add BAL information to an existing QSO catalogue from BAL tables created using runbalfinder.py. Function concatbaltab in this module is currently in progress. 

Added appendbalinfo.py which calls functions from popqsotab.py to make the BAL catalogue. Meant to be an alternative to createbalcat.py.